### PR TITLE
Fixed typo "surviability" > "survivability"

### DIFF
--- a/GameData/KiwiTechTree/Configurations/Core/Main.cfg
+++ b/GameData/KiwiTechTree/Configurations/Core/Main.cfg
@@ -18,7 +18,7 @@
 // 29 October 2020: Fixed Upgrade for Twin-Boar introduced from 28 October update; Generalized the B9 Module Identifier for the engine upgrades to accommodate that not all use the newer ModuleEnginesFX
 // 31 October 2020: Adding general upgrade system to parts
 // 1 November 2020: Added more general upgrade system to parts
-// 11 November 2020: Added 1.10 parts; Moved the parachute single to surviability
+// 11 November 2020: Added 1.10 parts; Moved the parachute single to survivability
 
 // B9 Switch Patches
 // Add Plurals to B9 Modules if they don't already exist.
@@ -2179,7 +2179,7 @@
 // Tier 2 - basicFlightControl
 @PART[sasModule|monnopropMiniSphere] // 0.6 Reaction Wheel
 {
-	@TechRequired = basicFlightControl // Keep on surviability
+	@TechRequired = basicFlightControl // Keep on survivability
 }
 
 // Tier 3 - flightControl
@@ -2456,7 +2456,7 @@
 
 @PART[parachuteSingle]
 {
-	@TechRequired = surviability // Lost this in the conversion
+	@TechRequired = survivability // Lost this in the conversion
 	@cost = 472
 	@entryCost = 3500
 	parachuteUpgradeType = standard


### PR DESCRIPTION
This typo was preventing the stock MK16 parachute from being added to techtree