### PR TITLE
MM Patches to make some of my favourite KSP Mods fit with my very favourite KSP mod

### DIFF
--- a/GameData/KiwiTechTree/Configurations/Mods/KerbalFoundries2/KerbalFoundries.cfg
+++ b/GameData/KiwiTechTree/Configurations/Mods/KerbalFoundries2/KerbalFoundries.cfg
@@ -1,0 +1,66 @@
+// KTT Config for Kerbal Foundries gear
+
+//Aircraft Landing Gear
+@PART[KF-ALG-Smal*]:NEEDS[KiwiTechTree]:AFTER[KerbalFoundries]
+{
+	@TechRequired = stability
+}
+@PART[KF-ALG-Medium]:NEEDS[KiwiTechTree]:AFTER[KerbalFoundries]
+{
+	@TechRequired = landing
+}
+@PART[KF-ALG-Large]:NEEDS[KiwiTechTree]:AFTER[KerbalFoundries]
+{
+	@TechRequired = fieldScience
+}
+
+//Misc Skid and Marine Screwdrive
+@PART[KF-Skid]:NEEDS[KiwiTechTree]:AFTER[KerbalFoundries]
+{
+	@TechRequired = start
+}
+@PART[KF-ScrewDrive]:NEEDS[KiwiTechTree]:AFTER[KerbalFoundries]
+{
+	@TechRequired = fieldScience
+}
+
+//Wheels and Tracks
+@PART[KF-Track*]:NEEDS[KiwiTechTree]:AFTER[KerbalFoundries]
+{
+	@TechRequired = advLanding
+}
+@PART[KF-Wheel*]:NEEDS[KiwiTechTree]:AFTER[KerbalFoundries]
+{
+	@TechRequired = advLanding
+}
+@PART[KF-WheelTiny|KF-WheelSmall|KF-TrackSmall|KF-TrackTiny]:NEEDS[KiwiTechTree]:AFTER[KerbalFoundries]
+{
+	@TechRequired = landing
+}
+@PART[KF-WheelTruck*]:NEEDS[Grounded&KiwiTechTree]:AFTER[KerbalFoundries]
+{
+	@TechRequired = groundVehicles
+}
+
+//Landing Legs
+@PART[LegExtending]:NEEDS[KiwiTechTree]:AFTER[KerbalFoundries]
+{
+	@TechRequired = fieldScience
+}
+@PART[KF-LegAero|KF-LegFolding]:NEEDS[KiwiTechTree]:AFTER[KerbalFoundries]
+{
+	@TechRequired = heavyLanding
+}
+
+//Repulsors
+@PART[KF-KF-Repulsor*]:NEEDS[KiwiTechTree]:AFTER[KerbalFoundries]
+{
+	@TechRequired = advancedMotors
+}
+
+//APU
+@PART[KF-APU]:NEEDS[KiwiTechTree]:AFTER[KerbalFoundries]
+{
+	@TechRequired = advElectrics
+	@category = Electrical
+}

--- a/GameData/KiwiTechTree/Configurations/Mods/MechJeb/MechJebTechLevels.cfg
+++ b/GameData/KiwiTechTree/Configurations/Mods/MechJeb/MechJebTechLevels.cfg
@@ -1,4 +1,39 @@
-@PART[*]:HAS[@MODULE[MechJebCore],!MODULE[KerbalEVA]]
+// Kiwi's Tech Tree Overhaul (MechJeb2 by Sarbian Patch)
+// Version 1.0
+// Created: 31 March 2021 for KSP 1.11.2
+
+// Changes MJ2 Tech unlocks for the MJ2 AR202 part to be 1 tier earlier than for command pods
+// Means you can get access to the MJ autopilots 1 tier earlier if you use the AR202 part.
+
+@PART[mumech_MJ2_AR202]:AFTER[KiwiTechTree]
+{
+  @TechRequired = start
+  @mass = 0.01
+  %MODULE[MechJebCore]
+  {
+    %MechJebLocalSettings
+    {
+      %MechJebModuleCustomWindowEditor { %unlockTechs = start }
+      %MechJebModuleSmartASS { %unlockTechs = basicFlightControl }
+      %MechJebModuleManeuverPlanner { %unlockTechs = basicFlightControl }
+      %MechJebModuleNodeEditor { %unlockTechs = start }
+      %MechJebModuleTranslatron { %unlockTechs = basicFlightControl }
+      %MechJebModuleWarpHelper { %unlockTechs = start }
+      %MechJebModuleAttitudeAdjustment { %unlockTechs = basicFlightControl }
+      %MechJebModuleThrustWindow { %unlockTechs = basicFlightControl }
+      %MechJebModuleRCSBalancerWindow { %unlockTechs = basicFlightControl }
+      %MechJebModuleRoverWindow { %unlockTechs = flightControl }
+      %MechJebModuleAscentGuidance { %unlockTechs = flightControl }
+      %MechJebModuleLandingGuidance { %unlockTechs = advFlightControl }
+      %MechJebModuleSpaceplaneGuidance { %unlockTechs = advFlightControl }
+      %MechJebModuleDockingGuidance { %unlockTechs = advFlightControl }
+      %MechJebModuleRendezvousAutopilotWindow { %unlockTechs = advFlightControl }
+      %MechJebModuleRendezvousGuidance { %unlockTechs = flightControl }
+    }
+  }
+}
+
+@PART[*]:HAS[@MODULE[MechJebCore],!MODULE[KerbalEVA]]:AFTER[MechJeb2,KiwiTechTree]
 {
   %MODULE[MechJebCore]
   {

--- a/GameData/KiwiTechTree/Configurations/Mods/ResearchBodies/ResearchBodies.cfg
+++ b/GameData/KiwiTechTree/Configurations/Mods/ResearchBodies/ResearchBodies.cfg
@@ -1,0 +1,8 @@
+// Kiwi's Tech Tree Overhaul (ResearchBodies by Jplrepo Patch)
+// Version 1.0
+// Created: 31 March 2021 for KSP 1.11.2
+
+@PART[TrackBodiesTelescope]:AFTER[ResearchBodies]
+{
+	@TechRequired = basicScience
+}


### PR DESCRIPTION
MechJeb2 Patch - Fixes previous MJ2 Patch + Adds config so that the MJ2 part (AR202) gets the autopilots 1 tier earlier than command modules. So you are able to use the MJ autopilots earlier if you attach the somewhat awkward (and now heavier) AR202 part. Simulates tech being available in a bulky part before being integrated into the command pod.

Kerbal Foundries2 - Much better than stock wheels and, imho better than Airplane Plus parts. Parts moved to same nodes in tech tree as their Stock and Airplane+ equivalents.

Research Bodies - Really simple patch, just moves the Research Bodies orbital telescope to Basic Science node