### PR TITLE
fix kiwi-reactionwheels node size

### DIFF
--- a/GameData/KiwiTechTree/Parts/Control/kiwi-reactionwheel-375-1.cfg
+++ b/GameData/KiwiTechTree/Parts/Control/kiwi-reactionwheel-375-1.cfg
@@ -4,6 +4,8 @@
 {
 	@name = kiwi-reactionwheel-375-1
 	@rescaleFactor = 2
+	@node_stack_top[6]    = 3
+	@node_stack_bottom[6] = 3
 	@entryCost *= 2
 	@cost *= 2
 	@TechRequired = experimentalControl

--- a/GameData/KiwiTechTree/Parts/Control/kiwi-reactionwheel-5-1.cfg
+++ b/GameData/KiwiTechTree/Parts/Control/kiwi-reactionwheel-5-1.cfg
@@ -14,6 +14,8 @@
 		cube = Default, 1.245,0.7807,1.345, 1.245,0.7807,1.345, 4.643,0.9184,0.5737, 4.643,0.959,0.5463, 1.245,0.7746,1.345, 1.245,0.7746,1.345, 0,0,0, 2.5,0.5,2.5
     }
     %rescaleFactor = 2
+	@node_stack_top[6]    = 4
+	@node_stack_bottom[6] = 4
 	@entryCost *= 2
 	@cost *= 2
 	@TechRequired = exoticControl


### PR DESCRIPTION
fix kiwi-reactionwheels node size, 
`rescaleFactor` move nodes, but does not change their size